### PR TITLE
added 'watched' to user_movies

### DIFF
--- a/db/migrate/20180605151536_add_watched_to_user_movies.rb
+++ b/db/migrate/20180605151536_add_watched_to_user_movies.rb
@@ -1,0 +1,5 @@
+class AddWatchedToUserMovies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user_movies, :watched, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_31_172307) do
+ActiveRecord::Schema.define(version: 2018_06_05_151536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 2018_05_31_172307) do
     t.bigint "movie_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "watched"
     t.index ["movie_id"], name: "index_user_movies_on_movie_id"
     t.index ["user_id"], name: "index_user_movies_on_user_id"
   end


### PR DESCRIPTION
updated the user_movies table to have a boolean paramater called "watched". If it's true it'll be in our catalogue, if it's false it will be in our watchlist.

We'll use user_movies objects to show movies on the index page. If a relationship exists (catalog [true] or watchlist [false]), by default it will no longer show up as a suggestion on the index page.